### PR TITLE
Adds an overmap marker to the pizzeria

### DIFF
--- a/maps/ministation/ministation.dm
+++ b/maps/ministation/ministation.dm
@@ -19,6 +19,7 @@ Now poorly imported for Nebula!
 	#include "ministation_telecomms.dm"
 	#include "ministation_jobs.dm"
 	#include "pizzeria_spawnpoints.dm"
+	#include "pizzeria_overmap.dm"
 
 	#include "jobs/animatronics.dm"
 	#include "jobs/command.dm"

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -408,11 +408,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/pizzeria/dining)
-"nn" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/machinery/cryopod/animatronic,
-/turf/simulated/floor/tiled/techmaint,
-/area/pizzeria/staff/maintenance)
 "ny" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
@@ -1165,11 +1160,6 @@
 	},
 /turf/exterior/concrete/road,
 /area/pizzeria/outside)
-"Kj" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/structure/table,
-/turf/simulated/floor/tiled/techfloor,
-/area/pizzeria/staff/security)
 "Kx" = (
 /obj/machinery/light{
 	dir = 4
@@ -1698,12 +1688,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/pizzeria/staff/kitchen)
-"ZD" = (
-/obj/machinery/atmospherics/unary/vent_pump,
-/obj/structure/table/woodentable,
-/obj/item/chems/food/sliceable/pizza/vegetablepizza,
-/turf/simulated/floor/wood/walnut,
-/area/pizzeria/dining)
 "ZG" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/floor_decal/corner/white/diagonal{
@@ -5353,7 +5337,7 @@ fS
 KQ
 fS
 RZ
-ZD
+TK
 Ym
 Ym
 Ym
@@ -6456,7 +6440,7 @@ XV
 be
 Qz
 Xm
-Kj
+rn
 op
 Ay
 KI
@@ -7181,7 +7165,7 @@ fv
 cu
 Im
 RN
-nn
+wZ
 IZ
 My
 RN

--- a/maps/ministation/ministation.dmm
+++ b/maps/ministation/ministation.dmm
@@ -1595,6 +1595,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/pizzeria/staff/kitchen)
+"Xa" = (
+/obj/effect/overmap/visitable/sector/pizzeria,
+/turf/exterior/grass,
+/area/pizzeria/outside)
 "Xg" = (
 /obj/machinery/light_switch{
 	default_pixel_y = -32;
@@ -1826,7 +1830,7 @@ XV
 XV
 XV
 XV
-XV
+Xa
 "}
 (2,1,1) = {"
 XV

--- a/maps/ministation/ministation_define.dm
+++ b/maps/ministation/ministation_define.dm
@@ -15,6 +15,8 @@
 
 	default_law_type = /datum/ai_laws/nanotrasen
 
+	overmap_ids = list(OVERMAP_ID_SPACE)
+
 	lobby_screens = list('maps/ministation/ministation_lobby.png')
 
 	//TEMPORARY NOTE: Evac messages are temporary until its set up properly. Make sure they're changed later.

--- a/maps/ministation/pizzeria_overmap.dm
+++ b/maps/ministation/pizzeria_overmap.dm
@@ -1,0 +1,5 @@
+/obj/effect/overmap/visitable/sector/pizzeria
+	name = "Pizzeria"
+	color = "#00ffff"
+	free_landing = FALSE
+	sector_flags = OVERMAP_SECTOR_KNOWN|OVERMAP_SECTOR_BASE


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/fazworld-dev/fazworld/blob/dev/CONTRIBUTING.md -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in the PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Adds an overmap marker to the pizzeria.

## Why and what will this PR improve
Fixes some potential event runtimes from station_levels being unset.

## Authorship
Me.
<!-- Describe original authors of changes to credit them. -->